### PR TITLE
Added better control for the picker popup

### DIFF
--- a/src/fields/SmartColour/Component.tsx
+++ b/src/fields/SmartColour/Component.tsx
@@ -89,9 +89,14 @@ const SmartColourComponent: React.FC<Props> = props => {
           <Picker
             onChange={handleAddColorViaPicker}
             color={value}
-            onBlur={() => {
-              setIsAdding(false)
+            onBlur={(e) => {
+							if (e.relatedTarget === null) {
+                setIsAdding(false)
+              }
             }}
+            onKeyDown={(e) =>
+							(e.key === 'Enter' || e.key === 'Escape') && setIsAdding(false)
+						}
           />
 
           <input


### PR DESCRIPTION
Change keeps picker popup open when selecting the alpha after setting a color. Popup can be closed by clicking outside of the popup, or by pressing enter or select